### PR TITLE
fix missing folder on campa setup

### DIFF
--- a/campa/cli/main.py
+++ b/campa/cli/main.py
@@ -27,9 +27,9 @@ extract_features    Extract features from clustered dataset
 def _get_setup_parser():
     parser = argparse.ArgumentParser(description="Create configuration file ``campa.ini``.")
     parser.add_argument(
-        "--force",
+        "--quiet",
         action="store_true",
-        help="force recreation of ``campa.ini`` even if exists",
+        help="create default configuration file without asking for user input.",
     )
     return parser
 
@@ -144,7 +144,7 @@ class CAMPA:
         parser = _get_setup_parser()
         args = parser.parse_args(sys.argv[2:])
         # create and populate campa.ini
-        prepare_config(args)
+        prepare_config(**vars(args))
 
     def create_dataset(self):
         parser = _get_create_dataset_parser()

--- a/campa/cli/prepare_config.py
+++ b/campa/cli/prepare_config.py
@@ -5,7 +5,7 @@ import os
 from campa.constants import campa_config
 
 
-def prepare_config(args):
+def prepare_config(quiet=False):
     def get_yn_input():
         r = input()
         while r.lower() not in ("y", "n"):
@@ -49,14 +49,15 @@ def prepare_config(args):
         )
         campa_config.write()
 
-    print("Would you like to configure your campa.ini config now? (y/n)")
-    if get_yn_input():
-        # read config file
-        campa_config.EXPERIMENT_DIR = get_path_input("EXPERIMENT_DIR", campa_config.EXPERIMENT_DIR)
-        campa_config.BASE_DATA_DIR = get_path_input("BASE_DATA_DIR", campa_config.BASE_DATA_DIR)
-        campa_config.write()
-    else:
-        print("Exiting without setting up campa.ini")
+    if not quiet:
+        print("Would you like to configure your campa.ini config now? (y/n)")
+        if get_yn_input():
+            # read config file
+            campa_config.EXPERIMENT_DIR = get_path_input("EXPERIMENT_DIR", campa_config.EXPERIMENT_DIR)
+            campa_config.BASE_DATA_DIR = get_path_input("BASE_DATA_DIR", campa_config.BASE_DATA_DIR)
+            campa_config.write()
+        else:
+            print("Exiting without setting up campa.ini")
 
     # print currently registered data config files
     print(f"Currently registered data configs in {campa_config.config_fname}:")

--- a/campa/constants.py
+++ b/campa/constants.py
@@ -216,6 +216,7 @@ class CAMPAConfig:
         for data_config_name, data_config in self.data_configs.items():
             config.set("data", data_config_name, data_config)
         # write config
+        os.makedirs(Path(config_fname).parent, exist_ok=True)
         with open(config_fname, "w") as configfile:
             config.write(configfile)
         # set config_fname


### PR DESCRIPTION
Adressing #12 , now creates `~/.config` if does not exist. 